### PR TITLE
Preserve the trailing slash on paths when building URIs

### DIFF
--- a/src/urilib.erl
+++ b/src/urilib.erl
@@ -275,7 +275,11 @@ url_add_path(undefined, URL) ->
 
 url_add_path(Path, URL) ->
     Escaped = string:join([url_escape_path_segment(P) || P <- string:tokens(Path, "/")], "/"),
-    string:join([URL, Escaped], "/").
+    Joined = string:join([URL, Escaped], "/"),
+    case lists:suffix("/", Path) of
+        true -> string:concat(Joined, "/");
+        false -> Joined
+    end.
 
 
 -spec url_escape_path_segment(string()) -> string().

--- a/test/urilib_tests.erl
+++ b/test/urilib_tests.erl
@@ -57,6 +57,11 @@ build_variation10_test() ->
     Expect = "http://www.google.com/#foo",
     ?assertEqual(Expect, urilib:build(Params)).
 
+build_uri_path_with_trailing_slash_test() ->
+    Params = {https, undefined, "www.example.com", 443, "/foo/", undefined, undefined},
+    Expect = "https://www.example.com/foo/",
+    ?assertEqual(Expect, urilib:build(Params)).
+
 build_url_variation1_test() ->
     Params = {amqp, "guest", "password", "rabbitmq", 5672, "/%2f", [{"heartbeat", "5"}], undefined},
     Expect = "amqp://guest:password@rabbitmq:5672/%2f?heartbeat=5",
@@ -117,6 +122,11 @@ parse_uri_test() ->
     Expect = {amqp, {{"guest", "password"}, "rabbitmq", 5672}, "/%2f",
               [{"heartbeat", "5"}], undefined},
     ?assertEqual(Expect, urilib:parse(URI, uri)).
+
+parse_uri_with_trailing_slash_test() ->
+    URI = "https://www.example.com/foo/",
+    Expect = {https, {undefined, "www.example.com", 443}, "/foo/", undefined, undefined},
+    ?assertEqual(Expect, urilib:parse(URI)).
 
 parse_url_variation1_test() ->
     URI = "amqp://guest:password@rabbitmq:5672/%2f?heartbeat=5&foo=bar&baz+corgie=qux+grault",


### PR DESCRIPTION
Paths with and without trailing slashes are distinct, therefore a
trailing slash in the path should be preserved when building the URI.