### PR TITLE
Fix extra slash being added on root path URIs

### DIFF
--- a/src/urilib.erl
+++ b/src/urilib.erl
@@ -274,7 +274,7 @@ url_add_path(undefined, URL) ->
 url_add_path(Path, URL) ->
     Escaped = string:join([url_escape_path_segment(P) || P <- string:tokens(Path, "/")], "/"),
     Joined = string:join([URL, Escaped], "/"),
-    case lists:suffix("/", Path) of
+    case Path /= "/" andalso lists:suffix("/", Path) of
         true -> string:concat(Joined, "/");
         false -> Joined
     end.

--- a/test/urilib_tests.erl
+++ b/test/urilib_tests.erl
@@ -62,6 +62,16 @@ build_uri_path_with_trailing_slash_test() ->
     Expect = "https://www.example.com/foo/",
     ?assertEqual(Expect, urilib:build(Params)).
 
+build_uri_path_with_root_path_test() ->
+    Params = {https, undefined, "www.example.com", 443, "/", undefined, undefined},
+    Expect = "https://www.example.com/",
+    ?assertEqual(Expect, urilib:build(Params)).
+
+build_uri_path_with_no_path_test() ->
+    Params = {https, undefined, "www.example.com", 443, "", undefined, undefined},
+    Expect = "https://www.example.com/",
+    ?assertEqual(Expect, urilib:build(Params)).
+
 build_url_variation1_test() ->
     Params = {amqp, "guest", "password", "rabbitmq", 5672, "/%2f", [{"heartbeat", "5"}], undefined},
     Expect = "amqp://guest:password@rabbitmq:5672/%2f?heartbeat=5",


### PR DESCRIPTION
The following bug was introduced in d6de7e83:

{https, undefined, "www.example.com", 443, "/", undefined, undefined},
  was being built as
"https://www.example.com//"

This corrects the issue by not appending a slash when the root
path ("/") is specified (it should behave the same as passing an
empty ("") path).