### PR TITLE
Correct type specifications of parse/1,2

### DIFF
--- a/src/urilib.erl
+++ b/src/urilib.erl
@@ -72,8 +72,11 @@ build({Scheme, Username, Password, Host, Port, Path, Query, Fragment}) ->
     url_maybe_add_fragment(Fragment, U5).
 
 
--spec parse(string()) -> uri().
+-spec parse(string()) -> uri() | {error, Reason :: term()}.
 %% @doc Parse a URI
+%%
+%% Returns either the URI or an error term.
+%%
 %% @end
 parse(Value) ->
     case http_uri:parse(Value, [{scheme_defaults, http_uri:scheme_defaults()}, {fragment, true}]) of
@@ -84,8 +87,11 @@ parse(Value) ->
     end.
 
 
--spec parse(string(), Return :: uri | url) -> uri().
+-spec parse(string(), Return :: uri | url) -> uri() | {error, Reason :: term()}.
 %% @doc Parse a URI, returning the result as either a {@type uri()} or {@type url()}.
+%%
+%% On error, return an error term.
+%%
 %% @end
 parse(Value, uri) ->
     parse(Value);


### PR DESCRIPTION
The type specification says the functions cannot err, though the code
clearly shows that as a possible outcome. This means users of the
dialyzer will get warnings in their code bases if they rely on the
error handling and matches on the error term.

Solve this by adding the right kind of type specification to the
different parts of the code base.